### PR TITLE
Fixing get_key to pass self._url to refresh_cache()

### DIFF
--- a/openid.py
+++ b/openid.py
@@ -58,7 +58,7 @@ class OpenIDConnectConfiguration(object):
 
         # Refresh the cache if it's more than 5 days old.
         if diff.total_seconds() > 5 * 24 * 60 * 60:
-            refresh_cache()
+            refresh_cache(self._url)
 
         keys  = OpenIDConnectConfiguration.signing_keys.get(self._url)
         if keys is not None:


### PR DESCRIPTION
There's a bug in `openid.py` in the function `get_key` where `refresh_cache` is being called without passing required `url` parameter.
This PR fixes the issue.